### PR TITLE
implemented limit for recursive includes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,11 +66,27 @@ For this to work, a couple of conventions must be followed. For example, css sho
 
 Include tags are resolved in parallel. Included content can again specify includes using the *include* tag. When building the response, these include tags are resolved recursively. Asset links are written "in order", the order is determined by the order in which include tags occur.
 
+The maximal depth for the recursion can be limited via the configuration property `composer.html.max-recursion`. If the limit is exceeded, the *fallback* for the include is used. 
+
+**Fallback content**
+
+If an include could not be resolved (for example, because the endpoint called for content returned an empty response), the markup enclosed by the *include* tag can specify a fallback. Here, the *content* tag can be used to mark the part that should be used as fallback content.
+
+*Example*
+```
+<rewe-digital-include path="returns/empty/response">
+    <div>not part of fallback</div>
+    <rewe-digital-content>
+        <div>the fallback</div>
+    </rewe-digital-content>
+</rewe-digital-include>
+``` 
+
 ### Session handling
 
 **Session data management**
 
-Composer contains an optional (toggled via configuration) session mechanism. A session is stored as encrypted cookie. Session values are forwared to called services (template and content) as http headers using the prefix `x-rd-`. So, a session value named `foo` with value `bar` would be forwarded as `x-rd-foo: bar`. 
+Composer contains an optional (toggled via configuration) session mechanism. A session is stored as encrypted cookie. Session values are forwarded to called services (template and content) as http headers using the prefix `x-rd-`. So, a session value named `foo` with value `bar` would be forwarded as `x-rd-foo: bar`. 
 
 Services can set session values by sending the appropriate response header. Thus, a service (template or content fragment) sending the response header `x-rd-foo: bar` would set a new or overwrite an existing session attribute named `foo` with the value `bar`. To remove a session attribute, an empty value can be provided.
 

--- a/src/main/java/com/rewedigital/composer/composing/ComposerHtmlConfiguration.java
+++ b/src/main/java/com/rewedigital/composer/composing/ComposerHtmlConfiguration.java
@@ -1,22 +1,31 @@
 package com.rewedigital.composer.composing;
 
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
 
 public class ComposerHtmlConfiguration {
 
     private final String includeTag;
     private final String contentTag;
     private final String assetOptionsAttribute;
+    private final int maxRecursion;
 
     public static ComposerHtmlConfiguration fromConfig(final Config config) {
+        final int maxRecursion = config.getInt("max-recursion");
+        if (maxRecursion < 0) {
+            throw new ConfigException.BadValue("max-recursion", "must be positive");
+        }
+
         return new ComposerHtmlConfiguration(config.getString("include-tag"), config.getString("content-tag"),
-            config.getString("asset-options-attribute"));
+            config.getString("asset-options-attribute"), maxRecursion);
     }
 
-    ComposerHtmlConfiguration(final String includeTag, final String contentTag, final String assetOptionsAttribute) {
+    ComposerHtmlConfiguration(final String includeTag, final String contentTag, final String assetOptionsAttribute,
+        final int maxRecursion) {
         this.includeTag = includeTag;
         this.contentTag = contentTag;
         this.assetOptionsAttribute = assetOptionsAttribute;
+        this.maxRecursion = maxRecursion;
     }
 
     public String includeTag() {
@@ -29,5 +38,9 @@ public class ComposerHtmlConfiguration {
 
     public String assetOptionsAttribute() {
         return assetOptionsAttribute;
+    }
+
+    public int maxRecursion() {
+        return maxRecursion;
     }
 }

--- a/src/main/java/com/rewedigital/composer/composing/Composition.java
+++ b/src/main/java/com/rewedigital/composer/composing/Composition.java
@@ -17,7 +17,7 @@ class Composition {
     private final ContentRange contentRange;
     private final SessionFragment session;
 
-    public Composition(final String template, final ContentRange contentRange, final List<String> assetLinks,
+    private Composition(final String template, final ContentRange contentRange, final List<String> assetLinks,
         final List<Composition> children) {
         this(0, template.length(), template, contentRange, assetLinks, SessionFragment.empty(), children);
     }
@@ -44,12 +44,11 @@ class Composition {
             this.session.mergedWith(session), children);
     }
 
-    public static Composition forRoot(final String template, final ContentRange contentRange,
+    public static Composition of(final String template, final ContentRange contentRange,
         final List<String> assetLinks, final List<Composition> children) {
         return new Composition(template, contentRange, assetLinks, children);
     }
 
-    // TODO TV make the recursion more explicit
     private String body() {
         final StringWriter writer = new StringWriter(template.length());
         int currentIndex = contentRange.start();

--- a/src/main/java/com/rewedigital/composer/composing/CompositionStep.java
+++ b/src/main/java/com/rewedigital/composer/composing/CompositionStep.java
@@ -1,0 +1,36 @@
+package com.rewedigital.composer.composing;
+
+public class CompositionStep {
+
+    private static final CompositionStep root = new CompositionStep(null, "", 0);
+
+    private final CompositionStep parent;
+    private final String path;
+    private final int depth;
+
+    public static CompositionStep root(final String path) {
+        return new CompositionStep(root, path, 0);
+    }
+
+    private CompositionStep(final CompositionStep parent, final String path, final int depth) {
+        this.parent = parent;
+        this.path = path;
+        this.depth = depth;
+    }
+
+    public int depth() {
+        return depth;
+    }
+
+    public CompositionStep childWith(final String path) {
+        return new CompositionStep(this, path, depth + 1);
+    }
+
+    public String callStack() {
+        if (this == root) {
+            return "[root]";
+        }
+
+        return "[" + path + "] included via " + parent.callStack();
+    }
+}

--- a/src/main/java/com/rewedigital/composer/composing/ContentComposer.java
+++ b/src/main/java/com/rewedigital/composer/composing/ContentComposer.java
@@ -5,5 +5,5 @@ import java.util.concurrent.CompletableFuture;
 import com.spotify.apollo.Response;
 
 interface ContentComposer {
-    CompletableFuture<Composition> composeContent(final Response<String> templateResponse);
+    CompletableFuture<Composition> composeContent(final Response<String> templateResponse, final CompositionStep step);
 }

--- a/src/main/java/com/rewedigital/composer/composing/ContentFetcher.java
+++ b/src/main/java/com/rewedigital/composer/composing/ContentFetcher.java
@@ -5,5 +5,5 @@ import java.util.concurrent.CompletableFuture;
 import com.spotify.apollo.Response;
 
 public interface ContentFetcher {
-    CompletableFuture<Response<String>> fetch(String path, String fallback);
+    CompletableFuture<Response<String>> fetch(String path, String fallback, CompositionStep step);
 }

--- a/src/main/java/com/rewedigital/composer/composing/IncludeMarkupHandler.java
+++ b/src/main/java/com/rewedigital/composer/composing/IncludeMarkupHandler.java
@@ -17,7 +17,6 @@ class IncludeMarkupHandler extends AbstractMarkupHandler {
 
     private final List<IncludedService> includedServices = new ArrayList<>();
     private final ContentMarkupHandler contentMarkupHandler;
-
     private Optional<IncludedService> include = Optional.empty();
     private StringWriter fallbackWriter;
     private IMarkupHandler next;
@@ -26,15 +25,14 @@ class IncludeMarkupHandler extends AbstractMarkupHandler {
 
     public IncludeMarkupHandler(final ContentRange defaultContentRange, final ComposerHtmlConfiguration configuration) {
         this.includeTag = configuration.includeTag().toCharArray();
-        contentMarkupHandler = new ContentMarkupHandler(defaultContentRange, configuration);
-        next = contentMarkupHandler;
+        this.contentMarkupHandler = new ContentMarkupHandler(defaultContentRange, configuration);
+        this.next = contentMarkupHandler;
     }
 
     public IncludeProcessor buildProcessor(final String template) {
         return new IncludeProcessor(template, includedServices, contentRange(),
             assetLinks());
     }
-
 
     private ContentRange contentRange() {
         return contentMarkupHandler.contentRange();

--- a/src/main/java/com/rewedigital/composer/composing/IncludeProcessor.java
+++ b/src/main/java/com/rewedigital/composer/composing/IncludeProcessor.java
@@ -23,17 +23,17 @@ class IncludeProcessor {
     }
 
     public CompletableFuture<Composition> composeIncludes(final ContentFetcher contentFetcher,
-        final ContentComposer composer) {
+        final ContentComposer composer, final CompositionStep step) {
         final Stream<CompletableFuture<Composition>> composedIncludes = includedServices.stream()
             .filter(s -> s.isInRage(contentRange))
-            .map(s -> s.fetch(contentFetcher)
+            .map(s -> s.fetch(contentFetcher, step)
                 .thenCompose(r -> r.compose(composer)));
         return flatten(composedIncludes)
-            .thenApply(c -> Composition.forRoot(template, contentRange, assetLinks, c.collect(toList())));
+            .thenApply(c -> Composition.of(template, contentRange, assetLinks, c.collect(toList())));
     }
 
     private static <T> CompletableFuture<Stream<T>> flatten(final Stream<CompletableFuture<T>> com) {
-        final List<CompletableFuture<T>> list = com.map(c -> c.toCompletableFuture()).collect(Collectors.toList());
+        final List<CompletableFuture<T>> list = com.collect(Collectors.toList());
         return CompletableFuture.allOf(list.toArray(new CompletableFuture[list.size()]))
             .thenApply(v -> list.stream().map(CompletableFuture::join));
     }

--- a/src/main/java/com/rewedigital/composer/composing/IncludedService.java
+++ b/src/main/java/com/rewedigital/composer/composing/IncludedService.java
@@ -26,7 +26,9 @@ class IncludedService {
             this.response = response;
             this.step = step;
 
-            LOGGER.debug("included service response: {} received via {}", response, step.callStack());
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("included service response: {} received via {}", response, step.callStack());
+            }
         }
 
         public CompletableFuture<Composition> compose(final ContentComposer contentComposer) {

--- a/src/main/java/com/rewedigital/composer/composing/IncludedService.java
+++ b/src/main/java/com/rewedigital/composer/composing/IncludedService.java
@@ -4,24 +4,34 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.spotify.apollo.Response;
 
 class IncludedService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IncludedService.class);
 
     public static class WithResponse {
         private final int startOffset;
         private final int endOffset;
         private final Response<String> response;
+        private final CompositionStep step;
 
-        private WithResponse(final int startOffset, final int endOffset, final Response<String> response) {
+        private WithResponse(final CompositionStep step, final int startOffset, final int endOffset,
+            final Response<String> response) {
             this.startOffset = startOffset;
             this.endOffset = endOffset;
             this.response = response;
+            this.step = step;
+
+            LOGGER.debug("included service response: {} received via {}", response, step.callStack());
         }
 
         public CompletableFuture<Composition> compose(final ContentComposer contentComposer) {
             return contentComposer
-                .composeContent(response)
+                .composeContent(response, step)
                 .thenApply(c -> c.forRange(startOffset, endOffset));
         }
     }
@@ -47,8 +57,11 @@ class IncludedService {
         this.fallback = fallback;
     }
 
-    public CompletableFuture<IncludedService.WithResponse> fetch(final ContentFetcher fetcher) {
-        return fetcher.fetch(path(), fallback()).thenApply(r -> new WithResponse(startOffset, endOffset, r));
+    public CompletableFuture<IncludedService.WithResponse> fetch(final ContentFetcher fetcher,
+        final CompositionStep parentStep) {
+        final CompositionStep step = parentStep.childWith(path());
+        return fetcher.fetch(path(), fallback(), step)
+            .thenApply(r -> new WithResponse(step, startOffset, endOffset, r));
     }
 
     private String fallback() {

--- a/src/main/java/com/rewedigital/composer/composing/RecursionAwareContentFetcher.java
+++ b/src/main/java/com/rewedigital/composer/composing/RecursionAwareContentFetcher.java
@@ -1,5 +1,6 @@
 package com.rewedigital.composer.composing;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.slf4j.Logger;
@@ -15,7 +16,7 @@ public class RecursionAwareContentFetcher implements ContentFetcher {
     private final int maxRecursion;
 
     public RecursionAwareContentFetcher(final ContentFetcher contentFetcher, final int maxRecursion) {
-        this.contentFetcher = contentFetcher;
+        this.contentFetcher = Objects.requireNonNull(contentFetcher);
         this.maxRecursion = maxRecursion;
     }
 

--- a/src/main/java/com/rewedigital/composer/composing/RecursionAwareContentFetcher.java
+++ b/src/main/java/com/rewedigital/composer/composing/RecursionAwareContentFetcher.java
@@ -1,0 +1,32 @@
+package com.rewedigital.composer.composing;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.spotify.apollo.Response;
+
+public class RecursionAwareContentFetcher implements ContentFetcher {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecursionAwareContentFetcher.class);
+
+    private final ContentFetcher contentFetcher;
+    private final int maxRecursion;
+
+    public RecursionAwareContentFetcher(final ContentFetcher contentFetcher, final int maxRecursion) {
+        this.contentFetcher = contentFetcher;
+        this.maxRecursion = maxRecursion;
+    }
+
+    @Override
+    public CompletableFuture<Response<String>> fetch(final String path, final String fallback,
+        final CompositionStep step) {
+        if (maxRecursion < step.depth()) {
+            LOGGER.warn("Max recursion depth execeeded for " + step.callStack());
+            return CompletableFuture.completedFuture(Response.forPayload(fallback));
+        }
+        return contentFetcher.fetch(path, fallback, step);
+    }
+
+}

--- a/src/main/java/com/rewedigital/composer/composing/TemplateComposer.java
+++ b/src/main/java/com/rewedigital/composer/composing/TemplateComposer.java
@@ -8,6 +8,7 @@ import com.spotify.apollo.Response;
 
 public interface TemplateComposer {
 
-    CompletableFuture<ResponseWithSession<String>> composeTemplate(final Response<String> templateResponse);
+    public CompletableFuture<ResponseWithSession<String>> composeTemplate(final Response<String> templateResponse,
+        final String path);
 
 }

--- a/src/main/java/com/rewedigital/composer/composing/ValidatingContentFetcher.java
+++ b/src/main/java/com/rewedigital/composer/composing/ValidatingContentFetcher.java
@@ -32,9 +32,10 @@ public class ValidatingContentFetcher implements ContentFetcher {
     }
 
     @Override
-    public CompletableFuture<Response<String>> fetch(final String path, final String fallback) {
+    public CompletableFuture<Response<String>> fetch(final String path, final String fallback,
+        final CompositionStep step) {
         if (path == null || path.trim().isEmpty()) {
-            LOGGER.warn("Empty path attribute in include found");
+            LOGGER.warn("Empty path attribute in include found - callstack: " + step.callStack());
             return CompletableFuture.completedFuture(Response.forPayload(""));
         }
 

--- a/src/main/java/com/rewedigital/composer/configuration/DefaultConfiguration.java
+++ b/src/main/java/com/rewedigital/composer/configuration/DefaultConfiguration.java
@@ -25,13 +25,14 @@ public class DefaultConfiguration {
         result.put("composer.html.include-tag", "rewe-digital-include");
         result.put("composer.html.content-tag", "rewe-digital-content");
         result.put("composer.html.asset-options-attribute", "data-rd-options");
+        result.put("composer.html.max-recursion", 5);
 
         result.put("composer.session.enabled", Boolean.TRUE);
         result.put("composer.session.cookie", "rdsession");
         result.put("composer.session.signing-algorithm", "HS512");
         result.put("composer.session.signing-key", "123");
         result.put("composer.session.interceptors", Collections.<ConfigValue>emptyList());
-        
+
         result.put("composer.routing.local-routes", Collections.<ConfigValue>emptyList());
         return result;
     }

--- a/src/main/resources/composer.conf
+++ b/src/main/resources/composer.conf
@@ -9,6 +9,7 @@ http.server.port = ${?HTTP_PORT}
 composer.html.include-tag = rewe-digital-include
 composer.html.content-tag = rewe-digital-content
 composer.html.asset-options-attribute = data-rd-options
+composer.html.max-recursion = 5
 
 # session configuration
 composer.session.enabled = true

--- a/src/test/java/com/rewedigital/composer/composing/ComposerHtmlConfigurationTest.java
+++ b/src/test/java/com/rewedigital/composer/composing/ComposerHtmlConfigurationTest.java
@@ -1,0 +1,24 @@
+package com.rewedigital.composer.composing;
+
+import org.junit.Test;
+
+import com.rewedigital.composer.configuration.DefaultConfiguration;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigValueFactory;
+
+public class ComposerHtmlConfigurationTest {
+
+    @Test
+    public void readsDefaultConfiguration() {
+        ComposerHtmlConfiguration
+            .fromConfig(DefaultConfiguration.defaultConfiguration().getConfig("composer.html"));
+    }
+
+    @Test(expected = ConfigException.BadValue.class)
+    public void validatesMaxRecursionConfiguration() {
+        ComposerHtmlConfiguration
+            .fromConfig(DefaultConfiguration.defaultConfiguration().getConfig("composer.html")
+                .withValue("max-recursion", ConfigValueFactory.fromAnyRef(-1)));
+    }
+
+}

--- a/src/test/java/com/rewedigital/composer/composing/ContentMarkupHandlerTest.java
+++ b/src/test/java/com/rewedigital/composer/composing/ContentMarkupHandlerTest.java
@@ -9,17 +9,13 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.rewedigital.composer.composing.ComposerHtmlConfiguration;
-import com.rewedigital.composer.composing.ContentMarkupHandler;
-import com.rewedigital.composer.composing.ContentRange;
-
 public class ContentMarkupHandlerTest {
 
     private static final ContentRange defaultContentRange = new ContentRange(123, 456);
 
     @Test
     public void parsesStylesheetLinksFromHead() {
-        List<String> result = parse("<!DOCTYPE html><html>\n" +
+        final List<String> result = parse("<!DOCTYPE html><html>\n" +
             "<head>"
             + "<link href=\"../static/css/core.css\" data-rd-options=\"include-in-head\" rel=\"stylesheet\" media=\"screen\" />"
             + "<link href=\"../static/css/other.css\" data-rd-options=\"include-in-head\" rel=\"stylesheet\" media=\"screen\"></link>"
@@ -51,7 +47,7 @@ public class ContentMarkupHandlerTest {
     private ContentMarkupHandler parse(final String data) {
         final ContentMarkupHandler markupHandler =
             new ContentMarkupHandler(defaultContentRange,
-                new ComposerHtmlConfiguration("", "rewe-digital-content", "data-rd-options"));
+                new ComposerHtmlConfiguration("", "rewe-digital-content", "data-rd-options", 1));
         PARSER.parse(data, markupHandler);
         return markupHandler;
     }

--- a/src/test/java/com/rewedigital/composer/composing/TemplateComposerTest.java
+++ b/src/test/java/com/rewedigital/composer/composing/TemplateComposerTest.java
@@ -29,7 +29,7 @@ public class TemplateComposerTest {
         final TemplateComposer composer = makeComposer(aClientWithSimpleContent("should not be included"));
 
         final Response<String> result = composer
-            .composeTemplate(r("template <rewe-digital-include></rewe-digital-include> content"), "template-path")
+            .composeTemplate(r("template <include></include> content"), "template-path")
             .get()
             .response();
 
@@ -43,7 +43,7 @@ public class TemplateComposerTest {
 
         final Response<String> result = composer
             .composeTemplate(r(
-                "template content <rewe-digital-include path=\"http://mock/\"></rewe-digital-include> more content"),
+                "template content <include path=\"http://mock/\"></include> more content"),
                 "template-path")
             .get().response();
 
@@ -55,7 +55,7 @@ public class TemplateComposerTest {
         final TemplateComposer composer = makeComposer(aClientWithSimpleContent("",
             "<link href=\"css/link\" data-rd-options=\"include\" rel=\"stylesheet\"/>"));
         final Response<String> result = composer
-            .composeTemplate(r("<head></head><rewe-digital-include path=\"http://mock/\"></rewe-digital-include>"),
+            .composeTemplate(r("<head></head><include path=\"http://mock/\"></include>"),
                 "template-path")
             .get().response();
         assertThat(result.payload()).contains(
@@ -68,10 +68,10 @@ public class TemplateComposerTest {
         final String innerContent = "some content";
         final TemplateComposer composer = makeComposer(
             aClientWithConsecutiveContent(
-                "<rewe-digital-include path=\"http://other/mock/\"></rewe-digital-include>",
+                "<include path=\"http://other/mock/\"></include>",
                 innerContent));
         final Response<String> result = composer
-            .composeTemplate(r("<rewe-digital-include path=\"http://mock/\"></rewe-digital-include>"), "template-path")
+            .composeTemplate(r("<include path=\"http://mock/\"></include>"), "template-path")
             .get().response();
         assertThat(result.payload()).contains(innerContent);
     }
@@ -81,8 +81,8 @@ public class TemplateComposerTest {
         final TemplateComposer composer = makeComposer(aClientReturning(Status.BAD_REQUEST));
         final Response<String> result = composer
             .composeTemplate(
-                r("template content <rewe-digital-include path=\"http://mock/\"><rewe-digital-content>"
-                    + "<div>default content</div></rewe-digital-content></rewe-digital-include>"),
+                r("template content <include path=\"http://mock/\"><content>"
+                    + "<div>default content</div></content></include>"),
                 "template-path")
             .get().response();
         assertThat(result.payload()).contains("template content <div>default content</div>");
@@ -95,7 +95,7 @@ public class TemplateComposerTest {
 
         final SessionRoot result = composer
             .composeTemplate(r(
-                "template content <rewe-digital-include path=\"http://mock/\"></rewe-digital-include> more content")
+                "template content <include path=\"http://mock/\"></include> more content")
                     .withHeader("x-rd-session-key-template", "session-val-template"),
                 "template-path")
             .get().session();
@@ -111,12 +111,12 @@ public class TemplateComposerTest {
         final String fallbackContent = "fallback";
         final TemplateComposer composer = makeComposerWithMaxRecursion(
             aClientWithConsecutiveContent(
-                "<rewe-digital-include path=\"include-exeecding-max-recursion\"><rewe-digital-content>"
-                    + fallbackContent + "</rewe-digital-content></rewe-digital-include>",
+                "<include path=\"include-exceeding-max-recursion\"><content>"
+                    + fallbackContent + "</content></include>",
                 "inner content should not be present"),
             maxRecursion);
         final Response<String> result = composer
-            .composeTemplate(r("<rewe-digital-include path=\"include-in-template\"></rewe-digital-include>"),
+            .composeTemplate(r("<include path=\"include-in-template\"></include>"),
                 "template-path")
             .get().response();
         assertThat(result.payload()).contains(fallbackContent);
@@ -130,7 +130,7 @@ public class TemplateComposerTest {
         final SessionRoot session = SessionRoot.empty();
         return new AttoParserBasedComposer(
             new ValidatingContentFetcher(client, Collections.emptyMap(), session), session,
-            new ComposerHtmlConfiguration("rewe-digital-include", "rewe-digital-content", "data-rd-options",
+            new ComposerHtmlConfiguration("include", "content", "data-rd-options",
                 maxRecursion));
     }
 
@@ -177,8 +177,8 @@ public class TemplateComposerTest {
     private Response<ByteString> contentResponse(final String content, final String head) {
         return Response
             .forPayload(
-                encodeUtf8("<html><head>" + head + "</head><body><rewe-digital-content>" + content
-                    + "</rewe-digital-content></body></html>"))
+                encodeUtf8("<html><head>" + head + "</head><body><content>" + content
+                    + "</content></body></html>"))
             .withHeader("Content-Type", "text/html");
     }
 

--- a/src/test/java/com/rewedigital/composer/composing/TemplateComposerTest.java
+++ b/src/test/java/com/rewedigital/composer/composing/TemplateComposerTest.java
@@ -15,10 +15,6 @@ import java.util.stream.Collectors;
 
 import org.junit.Test;
 
-import com.rewedigital.composer.composing.AttoParserBasedComposer;
-import com.rewedigital.composer.composing.ComposerHtmlConfiguration;
-import com.rewedigital.composer.composing.TemplateComposer;
-import com.rewedigital.composer.composing.ValidatingContentFetcher;
 import com.rewedigital.composer.session.SessionRoot;
 import com.spotify.apollo.Client;
 import com.spotify.apollo.Response;
@@ -33,7 +29,7 @@ public class TemplateComposerTest {
         final TemplateComposer composer = makeComposer(aClientWithSimpleContent("should not be included"));
 
         final Response<String> result = composer
-            .composeTemplate(r("template <rewe-digital-include></rewe-digital-include> content"))
+            .composeTemplate(r("template <rewe-digital-include></rewe-digital-include> content"), "template-path")
             .get()
             .response();
 
@@ -47,7 +43,8 @@ public class TemplateComposerTest {
 
         final Response<String> result = composer
             .composeTemplate(r(
-                "template content <rewe-digital-include path=\"http://mock/\"></rewe-digital-include> more content"))
+                "template content <rewe-digital-include path=\"http://mock/\"></rewe-digital-include> more content"),
+                "template-path")
             .get().response();
 
         assertThat(result.payload()).contains("template content " + content + " more content");
@@ -58,7 +55,8 @@ public class TemplateComposerTest {
         final TemplateComposer composer = makeComposer(aClientWithSimpleContent("",
             "<link href=\"css/link\" data-rd-options=\"include\" rel=\"stylesheet\"/>"));
         final Response<String> result = composer
-            .composeTemplate(r("<head></head><rewe-digital-include path=\"http://mock/\"></rewe-digital-include>"))
+            .composeTemplate(r("<head></head><rewe-digital-include path=\"http://mock/\"></rewe-digital-include>"),
+                "template-path")
             .get().response();
         assertThat(result.payload()).contains(
             "<head><link rel=\"stylesheet\" data-rd-options=\"include\" href=\"css/link\" />\n" +
@@ -73,7 +71,7 @@ public class TemplateComposerTest {
                 "<rewe-digital-include path=\"http://other/mock/\"></rewe-digital-include>",
                 innerContent));
         final Response<String> result = composer
-            .composeTemplate(r("<rewe-digital-include path=\"http://mock/\"></rewe-digital-include>"))
+            .composeTemplate(r("<rewe-digital-include path=\"http://mock/\"></rewe-digital-include>"), "template-path")
             .get().response();
         assertThat(result.payload()).contains(innerContent);
     }
@@ -83,9 +81,11 @@ public class TemplateComposerTest {
         final TemplateComposer composer = makeComposer(aClientReturning(Status.BAD_REQUEST));
         final Response<String> result = composer
             .composeTemplate(
-                r("template content <rewe-digital-include path=\"http://mock/\"><rewe-digital-content><div>default content</div></rewe-digital-content></rewe-digital-include>"))
+                r("template content <rewe-digital-include path=\"http://mock/\"><rewe-digital-content>"
+                    + "<div>default content</div></rewe-digital-content></rewe-digital-include>"),
+                "template-path")
             .get().response();
-        assertThat(result.payload().get()).contains("template content <div>default content</div>");
+        assertThat(result.payload()).contains("template content <div>default content</div>");
     }
 
     @Test
@@ -96,7 +96,8 @@ public class TemplateComposerTest {
         final SessionRoot result = composer
             .composeTemplate(r(
                 "template content <rewe-digital-include path=\"http://mock/\"></rewe-digital-include> more content")
-                    .withHeader("x-rd-session-key-template", "session-val-template"))
+                    .withHeader("x-rd-session-key-template", "session-val-template"),
+                "template-path")
             .get().session();
 
         assertThat(result.get("session-key-template")).contains("session-val-template");
@@ -104,11 +105,33 @@ public class TemplateComposerTest {
         assertThat(result.isDirty()).isTrue();
     }
 
+    @Test
+    public void limitsRecursionDepth() throws Exception {
+        final int maxRecursion = 1;
+        final String fallbackContent = "fallback";
+        final TemplateComposer composer = makeComposerWithMaxRecursion(
+            aClientWithConsecutiveContent(
+                "<rewe-digital-include path=\"include-exeecding-max-recursion\"><rewe-digital-content>"
+                    + fallbackContent + "</rewe-digital-content></rewe-digital-include>",
+                "inner content should not be present"),
+            maxRecursion);
+        final Response<String> result = composer
+            .composeTemplate(r("<rewe-digital-include path=\"include-in-template\"></rewe-digital-include>"),
+                "template-path")
+            .get().response();
+        assertThat(result.payload()).contains(fallbackContent);
+    }
+
     private TemplateComposer makeComposer(final Client client) {
+        return makeComposerWithMaxRecursion(client, 10);
+    }
+
+    private TemplateComposer makeComposerWithMaxRecursion(final Client client, final int maxRecursion) {
         final SessionRoot session = SessionRoot.empty();
         return new AttoParserBasedComposer(
             new ValidatingContentFetcher(client, Collections.emptyMap(), session), session,
-            new ComposerHtmlConfiguration("rewe-digital-include", "rewe-digital-content", "data-rd-options"));
+            new ComposerHtmlConfiguration("rewe-digital-include", "rewe-digital-content", "data-rd-options",
+                maxRecursion));
     }
 
     private Client aClientWithSimpleContent(final String content) {


### PR DESCRIPTION
* recursive includes are limited to a depth controlled via configuration
* include-stack is collected during request processing and used for improved log messages
* documentation in readme reflects new feature

Resolves #10